### PR TITLE
Remove Deprecated Yarn Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [Yahoo! APIs Terms of Use](https://developer.yahoo.com/terms/)
 
 `npm install -g https://github.com/tabrindle/yahoo-finance-cli`
 OR
-`yarn install -g yahoo-finance-cli `
+`yarn global add yahoo-finance-cli`
 
 ## Usage
 


### PR DESCRIPTION
Yarn has deprecated the -g flag in favor of using the global
command (ie `yarn global`).

Docs on global command here: https://yarnpkg.com/en/docs/cli/global